### PR TITLE
fix: auto-detect Zabbix version on auth failure for 7.2+ compatibility

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -148,7 +148,24 @@ async function getServerTriggers(
     user,
     pass,
     apiToken,
-    version
+    version,
+    async function(newVersion) {
+      // Persist auto-detected version to extension settings
+      try {
+        const settings = await getSettings();
+        if (settings && settings.servers) {
+          for (var i in settings.servers) {
+            if (settings.servers[i].url === server) {
+              console.log("Updating stored version for " + server + " to " + newVersion);
+              settings.servers[i].version = newVersion;
+            }
+          }
+          await browser.storage.local.set({[ZABBIX_SERVERS_KEY]: JSON.stringify(settings)});
+        }
+      } catch (e) {
+        console.log("Failed to persist auto-detected version: " + e.message);
+      }
+    }
   );
   let triggerResults = {};
   try {

--- a/src/lib/zabbix-promise.js
+++ b/src/lib/zabbix-promise.js
@@ -35,7 +35,7 @@ export var Zabbix = (function () {
    * @param {string} password - Zabbix user password
    */
 
-  function Zabbix(url, user, password, apiToken, version) {
+  function Zabbix(url, user, password, apiToken, version, onVersionChange) {
     _classCallCheck(this, Zabbix);
 
     this.url = url;
@@ -43,6 +43,7 @@ export var Zabbix = (function () {
     this.password = password;
     this.apiToken = apiToken;
     this.version = version;
+    this.onVersionChange = onVersionChange;
   }
 
   /**
@@ -55,7 +56,7 @@ export var Zabbix = (function () {
   _createClass(Zabbix, [
     {
       key: "call",
-      value: function call(method, params) {
+      value: async function call(method, params) {
         //console.log("ZABLIB method: " + JSON.stringify(method) + " Params: " + JSON.stringify(params))
         var request = {
           jsonrpc: "2.0",
@@ -70,7 +71,32 @@ export var Zabbix = (function () {
           }
         }
         //console.log("ZABLIB request: " + JSON.stringify(request))
-        return this._postJsonRpc(this.url, JSON.stringify(request));
+        var response = await this._postJsonRpc(this.url, JSON.stringify(request));
+
+        // Self-heal when server was upgraded but extension version config is stale.
+        // Zabbix 7.2+ removed the "auth" body parameter and rejects it outright.
+        if (response.error && response.error.data &&
+            response.error.data.includes('unexpected parameter "auth"')) {
+          console.log("ZABLIB auth parameter rejected — auto-detecting server version");
+          var versionResponse = await this._postJsonRpc(this.url, JSON.stringify({
+            jsonrpc: "2.0",
+            method: "apiinfo.version",
+            params: [],
+            id: "1"
+          }));
+          if (versionResponse.result) {
+            console.log("ZABLIB detected server version: " + versionResponse.result);
+            this.version = versionResponse.result;
+            if (this.onVersionChange) {
+              this.onVersionChange(this.version);
+            }
+            // Retry without auth in body
+            delete request["auth"];
+            response = await this._postJsonRpc(this.url, JSON.stringify(request));
+          }
+        }
+
+        return response;
       },
 
       /**


### PR DESCRIPTION
## Problem

Zabbix 7.2+ removed the `auth` body parameter from JSON-RPC API requests. Users who upgrade their Zabbix server without updating the version in the extension settings get:

```
Invalid parameter "/": unexpected parameter "auth".
```

The extension already handles the two auth methods (body param for <7.0, Bearer header for 7.0+), but the version is only read when updating settings; if the user upgrades their Zabbix server and doesn't update the extension config, auth breaks.

## Fix

Self-healing retry logic in `zabbix-promise.js`:

1. When the API rejects the `auth` body parameter, call `apiinfo.version` (unauthenticated) to detect the actual server version
2. Update the in-memory version and retry the request without `auth` in the body
3. Persist the detected version to `browser.storage.local` via an `onVersionChange` callback so subsequent polls work without the retry round-trip

### Changes

- **`src/lib/zabbix-promise.js`**: Constructor accepts optional `onVersionChange` callback; `call()` is now async with retry-on-auth-failure logic
- **`src/background.js`**: Passes `onVersionChange` callback that persists the auto-detected version to extension storage

Fixes #90