### PR TITLE
fix: bug fixes, code quality, and build improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "globals": "^15.14.0",
     "vite": "^8.0.13",
     "vite-plugin-eslint2": "^5.1.0",
-    "vite-plugin-render-svg": "^1.1.1",
     "vite-plugin-web-extension": "^4.4.3",
     "vue-plugin-webextension-i18n": "^0.1.3",
     "vuetify": "^3.7.9",

--- a/src/background.js
+++ b/src/background.js
@@ -7,7 +7,7 @@ import { encryptSettingKeys, decryptSettings } from './lib/crypto.js'
 const icon = (name) => `images/${name}.png`
 const ZABBIX_SERVERS_KEY = "ZabbixServers";
 const DEBUG = false;
-const log = (...args) => DEBUG && log(...args);
+const log = (...args) => DEBUG && console.log(...args);
 
 // Zabbix severity levels - replaces magic numbers 0-5
 const SEVERITY = Object.freeze({

--- a/src/lib/crypto.js
+++ b/src/lib/crypto.js
@@ -1,8 +1,8 @@
 import { sjcl } from './sjcl.js';
 
-var pass =  navigator.appName + navigator.language + navigator.platform;
-var salt = sjcl.codec.base64.fromBits(sjcl.hash.sha256.hash(navigator.appName));
-var decoderRing = sjcl.codec.hex.fromBits(sjcl.misc.pbkdf2(pass, salt));
+const pass =  navigator.appName + navigator.language + navigator.platform;
+const salt = sjcl.codec.base64.fromBits(sjcl.hash.sha256.hash(navigator.appName));
+const decoderRing = sjcl.codec.hex.fromBits(sjcl.misc.pbkdf2(pass, salt));
 
 const encryptSettingKeys = settings => {
     /*
@@ -18,7 +18,7 @@ const encryptSettingKeys = settings => {
 }
 
 const decryptSettings = encryptedData => {
-    var decrypted = sjcl.decrypt(decoderRing, encryptedData);
+    const decrypted = sjcl.decrypt(decoderRing, encryptedData);
     return decrypted;
 }
 

--- a/src/options/options.vue
+++ b/src/options/options.vue
@@ -190,7 +190,7 @@ import browser from "webextension-polyfill";
 import { encryptSettingKeys, decryptSettings } from '../lib/crypto.js'
 
 
-var severitySelect = [
+const severitySelect = [
   { name: browser.i18n.getMessage("notClassified"), priority: 0 },
   { name: browser.i18n.getMessage("information"), priority: 1 },
   { name: browser.i18n.getMessage("warning"), priority: 2 },
@@ -238,7 +238,7 @@ export default {
     };
   },
   async mounted() {
-    var zabbix_data;
+    let zabbix_data;
     zabbix_data = await browser.storage.local.get("ZabbixServers");
     if (Object.keys(zabbix_data).length > 0) {
       zabbix_data = zabbix_data["ZabbixServers"]
@@ -367,7 +367,7 @@ export default {
         this.zabbixs["servers"] = savedServerSettings;
 
         // encrypt pass and api fields
-        var ZabbixServers =  encryptSettingKeys(this.zabbixs);
+        const ZabbixServers =  encryptSettingKeys(this.zabbixs);
         await browser.storage.local.set({"ZabbixServers": JSON.stringify(ZabbixServers)});
         console.log("Options calling reinitalize")
         browser.runtime.sendMessage({ method: "reinitalize" });

--- a/src/popup/popup.vue
+++ b/src/popup/popup.vue
@@ -240,6 +240,14 @@ document.addEventListener("DOMContentLoaded", async function () {
   }, 300);
 });
 
+/**
+ * Parse a major or minor version segment as a number for safe comparison.
+ * Avoids string comparison bugs where "10" < "7".
+ */
+function versionPart(version, index) {
+  return parseInt(version.split(".")[index], 10) || 0;
+}
+
 export default {
   data() {
     return {
@@ -322,14 +330,14 @@ export default {
       window.open(url + "/hostinventories.php?hostid=" + hostid, "_blank");
     },
     latestData: function (url, version, hostid) {
-      if (version.split(".")[0] >= 7) {
+      if (versionPart(version, 0) >= 7) {
         window.open(
           url +
             "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&hostids%5B%5D=" +
             hostid,
           "_blank"
         );
-      } else if (version.split(".")[0] >= 5) {
+      } else if (versionPart(version, 0) >= 5) {
         window.open(
           url +
             "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&filter_hostids%5B%5D=" +
@@ -346,7 +354,7 @@ export default {
       }
     },
     hostGraphs: function (url, version, hostid) {
-      if (version.split(".")[0] >= 5) {
+      if (versionPart(version, 0) >= 5) {
         window.open(
           url +
             "/zabbix.php?action=charts.view&filter_set=1&view_as=showgraph&filter_search_type=0&filter_hostids%5B0%5D=" +
@@ -362,8 +370,8 @@ export default {
     },
     problemDetails: function (url, version, triggerid) {
       if (
-        version.split(".")[0] >= 5 ||
-        (version.split(".")[0] == 5 && version.split(".")[1] >= 2)
+        versionPart(version, 0) >= 5 ||
+        (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
       ) {
         window.open(
           url +
@@ -382,8 +390,8 @@ export default {
     },
     hostDashboards: function (url, version, hostid) {
       if (
-        version.split(".")[0] > 5 ||
-        (version.split(".")[0] == 5 && version.split(".")[1] >= 2)
+        versionPart(version, 0) > 5 ||
+        (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
       ) {
         window.open(
           url + "/zabbix.php?action=host.dashboard.view&hostid=" + hostid,
@@ -401,14 +409,14 @@ export default {
       );
     },
     ackEvent: function (url, version, triggerid, eventid) {
-      if (version.split(".")[0] >= 7) {
+      if (versionPart(version, 0) >= 7) {
         window.open(
           url +
             "/zabbix.php?action=popup&popup=acknowledge.edit&eventids%5B%5D=" +
             eventid,
           "_blank"
         );
-      } else if (version.split(".")[0] >= 5) {
+      } else if (versionPart(version, 0) >= 5) {
         window.open(
           url +
             "/zabbix.php?action=popup&popup_action=acknowledge.edit&eventids%5B%5D=" +

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,6 +22,7 @@ export default defineConfig({
   assetsInclude: ['*.mp3', '*.html'],
   build: {
     minify: true,
+    target: target === 'firefox' ? 'firefox109' : 'chrome110',
     outDir: '../dist',
     emptyOutDir: true,
   },


### PR DESCRIPTION
## Bug fixes
- **Fix recursive `log()` in background.js** — was calling itself instead of `console.log`, would stack overflow if `DEBUG` were enabled
- **Fix string-based version comparisons in popup.vue** — `version.split(".")[0] >= 7` did string comparison where `"10" < "7"`; now uses `parseInt()` via `versionPart()` helper

## Code quality
- Replace `var` with `const`/`let` in options.vue and crypto.js
- Remove unused `vite-plugin-render-svg` from devDependencies (replaced by prebuild script)

## Build
- Add explicit build target (`chrome110`/`firefox109`) based on `TARGET` env var — avoids unnecessary syntax transforms for older browsers