### PR TITLE
refactor: migrate popup.vue and options.vue to Composition API

### DIFF
--- a/src/options/options.vue
+++ b/src/options/options.vue
@@ -181,23 +181,23 @@
 </template>
 
 <script setup>
-import { mdiClose, mdiEye, mdiEyeOff, mdiReload } from '@mdi/js'
-</script>
-
-<script>
+import { ref, onMounted } from 'vue';
+import { mdiClose, mdiEye, mdiEyeOff, mdiReload } from '@mdi/js';
 import { Zabbix } from '../lib/zabbix-promise.js';
 import browser from "webextension-polyfill";
-import { encryptSettingKeys, decryptSettings } from '../lib/crypto.js'
+import { encryptSettingKeys, decryptSettings } from '../lib/crypto.js';
 
+const i18n = browser.i18n.getMessage;
 
-const severitySelect = [
-  { name: browser.i18n.getMessage("notClassified"), priority: 0 },
-  { name: browser.i18n.getMessage("information"), priority: 1 },
-  { name: browser.i18n.getMessage("warning"), priority: 2 },
-  { name: browser.i18n.getMessage("average"), priority: 3 },
-  { name: browser.i18n.getMessage("high"), priority: 4 },
-  { name: browser.i18n.getMessage("disaster"), priority: 5 },
+const severitySelector = [
+  { name: i18n("notClassified"), priority: 0 },
+  { name: i18n("information"), priority: 1 },
+  { name: i18n("warning"), priority: 2 },
+  { name: i18n("average"), priority: 3 },
+  { name: i18n("high"), priority: 4 },
+  { name: i18n("disaster"), priority: 5 },
 ];
+
 const defaultServer = {
   alias: "New Server",
   url: "",
@@ -212,208 +212,210 @@ const defaultServer = {
   visiblePass: false,
   errorMsg: "",
   sortBy: [{ key: 'priority', order: 'desc' }],
+};
+
+// Reactive state
+const form = ref(null);
+
+const zabbixs = ref({
+  global: {
+    interval: 60,
+    notify: true,
+    sound: false,
+    displayName: "host",
+    formValid: true,
+  },
+  servers: [
+    defaultServer
+  ],
+});
+
+const intervalRules = [
+  (v) => !!v || i18n("required"),
+  (v) => v > 9 || i18n("lessSeconds"),
+];
+
+let debounceTimeout = null;
+
+// Lifecycle
+onMounted(async () => {
+  let zabbix_data = await browser.storage.local.get("ZabbixServers");
+  if (Object.keys(zabbix_data).length > 0) {
+    zabbix_data = zabbix_data["ZabbixServers"];
+    zabbix_data = JSON.parse(zabbix_data);
+    for (let serverIndex in zabbix_data["servers"]) {
+      zabbix_data.servers[serverIndex].apiToken = decryptSettings(zabbix_data.servers[serverIndex].apiToken);
+      zabbix_data.servers[serverIndex].pass = decryptSettings(zabbix_data.servers[serverIndex].pass);
+      // Add fields for options screen
+      if (zabbix_data.servers[serverIndex].apiToken.length > 0) {
+        zabbix_data.servers[serverIndex].useToken = true;
+      } else {
+        zabbix_data.servers[serverIndex].useToken = false;
+      }
+      zabbix_data.servers[serverIndex].visiblePass = false;
+      zabbix_data.servers[serverIndex].hostGroupsList = [];
+    }
+    zabbixs.value = zabbix_data;
+  }
+});
+
+// Methods
+function serverAPI(val, index) {
+  /*
+   * Only run for the last update of the input field
+   * Query zabbix version api to confirm connectivity
+   */
+  if (debounceTimeout) {
+    // Reset timer on new data. Thus only run for latest input
+    clearTimeout(debounceTimeout);
+  }
+
+  debounceTimeout = setTimeout(async () => {
+    let url;
+    try {
+      url = new URL(val);
+    } catch (_) { // eslint-disable-line no-unused-vars
+      zabbixs.value.servers[index].errorMsg = i18n("requiredURL");
+      return false;
+    }
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      //console.log('protocol is okay')
+    } else {
+      zabbixs.value.servers[index].errorMsg = i18n("requiredURL");
+      return false;
+    }
+
+    // Request host permission for this server before testing API
+    const origin = url.origin + "/*";
+    try {
+      const hasPermission = await browser.permissions.contains({ origins: [origin] });
+      if (!hasPermission) {
+        const granted = await browser.permissions.request({ origins: [origin] });
+        if (!granted) {
+          zabbixs.value.servers[index].errorMsg = "Host permission required";
+          return false;
+        }
+      }
+    } catch (e) {
+      console.log("Permission request failed: " + e);
+    }
+
+    // validate zabbix connection with query zabbix api version and save in storage
+    const zabbix = new Zabbix(val + "/api_jsonrpc.php", null, null);
+    zabbix
+      .call("apiinfo.version", {})
+      .then((value) => {
+        zabbixs.value.servers[index].version = value["result"];
+        zabbixs.value.servers[index].errorMsg = "";
+        form.value.validate();
+        return true;
+      })
+      .catch((err) => {
+        console.log(i18n("serverError") + ": " + err);
+        zabbixs.value.servers[index].errorMsg = i18n("serverError");
+        zabbixs.value.servers[index].version = "";
+        return false;
+      });
+
+    //console.log("url looks okay!");
+    zabbixs.value.servers[index].errorMsg = "";
+    return true;
+  }, 800);
 }
 
-export default {
-  data() {
-    return {
-      zabbixs: {
-        global: {
-          interval: 60,
-          notify: true,
-          sound: false,
-          displayName: "host",
-          formValid: true,
-        },
-        servers: [
-          defaultServer
-        ],
-      },
-      severitySelector: severitySelect,
-      intervalRules: [
-        (v) => !!v || this.$i18n("required"),
-        (v) => v > 9 || this.$i18n("lessSeconds"),
-      ],
-      timeout: 800,
-    };
-  },
-  async mounted() {
-    let zabbix_data;
-    zabbix_data = await browser.storage.local.get("ZabbixServers");
-    if (Object.keys(zabbix_data).length > 0) {
-      zabbix_data = zabbix_data["ZabbixServers"]
-      zabbix_data = JSON.parse(zabbix_data);
-      for (let serverIndex in zabbix_data["servers"]) {
-        zabbix_data.servers[serverIndex].apiToken = decryptSettings(zabbix_data.servers[serverIndex].apiToken)
-        zabbix_data.servers[serverIndex].pass = decryptSettings(zabbix_data.servers[serverIndex].pass)
-        // Add fields for options screen
-        if (zabbix_data.servers[serverIndex].apiToken.length > 0) {
-          zabbix_data.servers[serverIndex].useToken = true;
-        } else {
-          zabbix_data.servers[serverIndex].useToken = false;
-        }
-        zabbix_data.servers[serverIndex].visiblePass = false;
-        zabbix_data.servers[serverIndex].hostGroupsList = [];
-      }
-      this.zabbixs = zabbix_data;
-    }
-  },
-  methods: {
-    serverAPI: function (val, index) {
-      /*
-       * Only run for the last update of the input field
-       * Query zabbix version api to confirm connectivity
-       */
-      if (this.timeout) {
-        // Reset timer on new data. Thus only run for latest input
-        clearTimeout(this.timeout);
-      }
+function addServer() {
+  zabbixs.value.servers.push(structuredClone(defaultServer));
+}
 
-      this.timeout = setTimeout(async () => {
-        let url;
-        try {
-          url = new URL(val);
-        } catch (_) { // eslint-disable-line no-unused-vars
-          this.zabbixs.servers[index].errorMsg = this.$i18n("requiredURL");
-          return false;
-        }
-        if (url.protocol === "http:" || url.protocol === "https:") {
-          //console.log('protocol is okay')
-        } else {
-          this.zabbixs.servers[index].errorMsg = this.$i18n("requiredURL");
-          return false;
-        }
+function removeServer(index) {
+  zabbixs.value.servers.splice(index, 1);
+}
 
-        // Request host permission for this server before testing API
-        const origin = url.origin + "/*";
+async function save_data() {
+  /*
+   * Save data to localstorage encrypted and close options window
+   * Message background.js to reload the new settings
+   */
+
+  if (form.value.validate()) {
+    // Request host permissions for each configured server URL
+    for (const server of zabbixs.value["servers"]) {
+      if (server.url) {
         try {
+          const url = new URL(server.url);
+          const origin = url.origin + "/*";
           const hasPermission = await browser.permissions.contains({ origins: [origin] });
           if (!hasPermission) {
             const granted = await browser.permissions.request({ origins: [origin] });
             if (!granted) {
-              this.zabbixs.servers[index].errorMsg = "Host permission required";
-              return false;
+              console.log("Permission denied for " + origin);
+              server.errorMsg = "Host permission required for " + url.origin;
+              return;
             }
           }
         } catch (e) {
-          console.log("Permission request failed: " + e);
+          console.log("Invalid server URL: " + server.url);
         }
-
-        // validate zabbix connection with query zabbix api version and save in storage
-        const zabbix = new Zabbix(val + "/api_jsonrpc.php", null, null);
-        zabbix
-          .call("apiinfo.version", {})
-          .then((value) => {
-            this.zabbixs.servers[index].version = value["result"];
-            this.zabbixs.servers[index].errorMsg = "";
-            this.$refs.form.validate();
-            return true;
-          })
-          .catch((err) => {
-            console.log(this.$i18n("serverError") + ": " + err);
-            this.zabbixs.servers[index].errorMsg = this.$i18n("serverError");
-            this.zabbixs.servers[index].version = "";
-            return false;
-          });
-
-        //console.log("url looks okay!");
-        this.zabbixs.servers[index].errorMsg = "";
-        return true;
-      }, 800);
-    },
-    addServer: function () {
-      this.zabbixs.servers.push(structuredClone(defaultServer));
-    },
-    removeServer: function (index) {
-      this.zabbixs.servers.splice(index, 1);
-    },
-    save_data: async function () {
-      /*
-       * Save data to localstorage encrypted and close options window
-       * Message background.js to reload the new settings
-       */
-
-      if (this.$refs.form.validate()) {
-        // Request host permissions for each configured server URL
-        for (const server of this.zabbixs["servers"]) {
-          if (server.url) {
-            try {
-              const url = new URL(server.url);
-              const origin = url.origin + "/*";
-              const hasPermission = await browser.permissions.contains({ origins: [origin] });
-              if (!hasPermission) {
-                const granted = await browser.permissions.request({ origins: [origin] });
-                if (!granted) {
-                  console.log("Permission denied for " + origin);
-                  server.errorMsg = "Host permission required for " + url.origin;
-                  return;
-                }
-              }
-            } catch (e) {
-              console.log("Invalid server URL: " + server.url);
-            }
-          }
-        }
-
-        // Do not save results of hostGroup lookups, password display, or errors
-        let savedServerSettings = this.zabbixs["servers"];
-        for (var i = 0; i < savedServerSettings.length; i++) {
-          savedServerSettings[i].errorMsg = "";
-          delete savedServerSettings[i].visiblePass;
-          delete savedServerSettings[i].useToken;
-          delete savedServerSettings[i].hostGroupsList;
-
-        }
-        this.zabbixs["servers"] = savedServerSettings;
-
-        // encrypt pass and api fields
-        const ZabbixServers =  encryptSettingKeys(this.zabbixs);
-        await browser.storage.local.set({"ZabbixServers": JSON.stringify(ZabbixServers)});
-        console.log("Options calling reinitalize")
-        browser.runtime.sendMessage({ method: "reinitalize" });
-        
-        window.close();
-      } else {
-        console.log("submit problem");
       }
-    },
-    refreshGroups: function (server, user, pass, apiToken, version, index) {
-      /*
-       * Connect to Zabbix server using provided credentials
-       * Perform hostgroup.get lookup and popuplate the hostgroup list
-       */
+    }
 
-      this.zabbixs["servers"][index]["errorMsg"] = "";
-      const zabbix = new Zabbix(
-        server + "/api_jsonrpc.php",
-        user,
-        pass,
-        apiToken,
-        version
-      );
-      zabbix
-        .login()
-        .then(() => {
-          //console.log('Successfully logged in');
-          let result = zabbix.call("hostgroup.get", {
-            output: ["groupid", "name"],
-          });
-          return result;
-        })
-        .then((value) => {
-          this.zabbixs["servers"][index].hostGroupsList = value["result"];
-        })
-        .catch((err) => {
-          this.zabbixs["servers"][index].hostGroupsList = [];
-          this.zabbixs["servers"][index]["errorMsg"] = err.message;
-          console.log(this.$i18n("serverError") + ": " + err);
-        })
-        .finally(() => {
-          zabbix.logout();
-        });
-    },
-  },
-};
+    // Do not save results of hostGroup lookups, password display, or errors
+    let savedServerSettings = zabbixs.value["servers"];
+    for (let i = 0; i < savedServerSettings.length; i++) {
+      savedServerSettings[i].errorMsg = "";
+      delete savedServerSettings[i].visiblePass;
+      delete savedServerSettings[i].useToken;
+      delete savedServerSettings[i].hostGroupsList;
+    }
+    zabbixs.value["servers"] = savedServerSettings;
+
+    // encrypt pass and api fields
+    const ZabbixServers = encryptSettingKeys(zabbixs.value);
+    await browser.storage.local.set({"ZabbixServers": JSON.stringify(ZabbixServers)});
+    console.log("Options calling reinitalize");
+    browser.runtime.sendMessage({ method: "reinitalize" });
+    
+    window.close();
+  } else {
+    console.log("submit problem");
+  }
+}
+
+function refreshGroups(server, user, pass, apiToken, version, index) {
+  /*
+   * Connect to Zabbix server using provided credentials
+   * Perform hostgroup.get lookup and populate the hostgroup list
+   */
+
+  zabbixs.value["servers"][index]["errorMsg"] = "";
+  const zabbix = new Zabbix(
+    server + "/api_jsonrpc.php",
+    user,
+    pass,
+    apiToken,
+    version
+  );
+  zabbix
+    .login()
+    .then(() => {
+      //console.log('Successfully logged in');
+      let result = zabbix.call("hostgroup.get", {
+        output: ["groupid", "name"],
+      });
+      return result;
+    })
+    .then((value) => {
+      zabbixs.value["servers"][index].hostGroupsList = value["result"];
+    })
+    .catch((err) => {
+      zabbixs.value["servers"][index].hostGroupsList = [];
+      zabbixs.value["servers"][index]["errorMsg"] = err.message;
+      console.log(i18n("serverError") + ": " + err);
+    })
+    .finally(() => {
+      zabbix.logout();
+    });
+}
 </script>
 
 <style></style>

--- a/src/popup/popup.vue
+++ b/src/popup/popup.vue
@@ -183,7 +183,7 @@
             v-if="serverObj.error"
             prominent
             type="error"
-            density=“compact”
+            density="compact"
           >
             {{ serverObj.errorMessage }}
             {{ serverObj.errorDetails }}
@@ -195,10 +195,8 @@
 </template>
 
 <script setup>
-import { mdiMagnify, mdiFlagVariant, mdiWrench } from '@mdi/js'
-</script>
-
-<script>
+import { ref, onMounted } from 'vue';
+import { mdiMagnify, mdiFlagVariant, mdiWrench } from '@mdi/js';
 import browser from "webextension-polyfill";
 
 // Zabbix severity levels - replaces magic numbers 0-5
@@ -212,7 +210,13 @@ const SEVERITY = Object.freeze({
   NONE: -1,
 });
 
+// Reactive state
+const triggerTableData = ref({
+  loading: true,
+  error: false,
+});
 
+// Data fetching
 async function getPopupData() {
   // Default to no servers defined
   let tableResults = {
@@ -225,16 +229,11 @@ async function getPopupData() {
     popupResults = popupResults["popupTable"]
     tableResults = popupResults;
   }
-  /*
-  triggerTable.data.error = true;
-  triggerTable.data.errorMessage = browser.i18n.getMessage("error");
-  */
   return tableResults;
 }
 
+// Display modifications to work around chrome issue 428044 (Tiny popup size)
 document.addEventListener("DOMContentLoaded", async function () {
-  // Display modifications to work around chrome issue 428044
-  // (Tiny popup size)
   setTimeout(() => {
     document.body.style.display = "block";
   }, 300);
@@ -248,191 +247,193 @@ function versionPart(version, index) {
   return parseInt(version.split(".")[index], 10) || 0;
 }
 
-export default {
-  data() {
-    return {
-      triggerTableData: {
-        "loading": true,
-        "error": false,
-      }
-    }
-  },
-  async mounted() {
-    this.triggerTableData = await getPopupData();
-  },
-  methods: {
-    priority_class: function (value) {
-      const PRIORITIES = {
-        [SEVERITY.NOT_CLASSIFIED]: "Cnotclassified",
-        [SEVERITY.INFORMATION]: "Cinformation",
-        [SEVERITY.WARNING]: "Cwarning",
-        [SEVERITY.AVERAGE]: "Caverage",
-        [SEVERITY.HIGH]: "Chigh",
-        [SEVERITY.DISASTER]: "Cdisaster",
-        9: "Cnormal",
-      };
-      return PRIORITIES[value];
-    },
-    priority_name_filter: function (value) {
-      const PRIORITY_NAMES = {
-        [SEVERITY.NOT_CLASSIFIED]: browser.i18n.getMessage("notClassified"),
-        [SEVERITY.INFORMATION]: browser.i18n.getMessage("information"),
-        [SEVERITY.WARNING]: browser.i18n.getMessage("warning"),
-        [SEVERITY.AVERAGE]: browser.i18n.getMessage("average"),
-        [SEVERITY.HIGH]: browser.i18n.getMessage("high"),
-        [SEVERITY.DISASTER]: browser.i18n.getMessage("disaster"),
-      };
-      return PRIORITY_NAMES[value];
-    },
-    date_filter: function (value) {
-      const curtime = new Date().getTime();
-      const diff = curtime - value * 1000;
+onMounted(async () => {
+  triggerTableData.value = await getPopupData();
+});
 
-      const seconds = parseInt(diff / 1000);
-      const minutes = parseInt(seconds / 60);
-      const hours = parseInt(minutes / 60);
-      const days = parseInt(hours / 24);
+// Methods (exposed to template automatically via <script setup>)
+function priority_class(value) {
+  const PRIORITIES = {
+    [SEVERITY.NOT_CLASSIFIED]: "Cnotclassified",
+    [SEVERITY.INFORMATION]: "Cinformation",
+    [SEVERITY.WARNING]: "Cwarning",
+    [SEVERITY.AVERAGE]: "Caverage",
+    [SEVERITY.HIGH]: "Chigh",
+    [SEVERITY.DISASTER]: "Cdisaster",
+    9: "Cnormal",
+  };
+  return PRIORITIES[value];
+}
 
-      let result = "";
-      if (days > 0) {
-        result += days + "d, ";
-      }
-      if (hours > 0) {
-        if (days < 1) {
-          result += (hours % 24) + "h, ";
-        } else {
-          result += (hours % 24) + "h";
-        }
-      }
-      if (days < 1) {
-        // Only show minutes if under a day
-        result += (minutes % 60) + "m";
-      }
+function priority_name_filter(value) {
+  const PRIORITY_NAMES = {
+    [SEVERITY.NOT_CLASSIFIED]: browser.i18n.getMessage("notClassified"),
+    [SEVERITY.INFORMATION]: browser.i18n.getMessage("information"),
+    [SEVERITY.WARNING]: browser.i18n.getMessage("warning"),
+    [SEVERITY.AVERAGE]: browser.i18n.getMessage("average"),
+    [SEVERITY.HIGH]: browser.i18n.getMessage("high"),
+    [SEVERITY.DISASTER]: browser.i18n.getMessage("disaster"),
+  };
+  return PRIORITY_NAMES[value];
+}
 
-      return result;
-    },
-    sortSave(value, serverIndex) {
-      browser.runtime.sendMessage({
-        method: "submitPagination",
-        index: serverIndex,
-        sortBy: value[0].key,
-        descending: value[0].order,
-      });
-    },
-    clickRow(item, serverIndex) {
-      if (this.triggerTableData.servers[serverIndex].expanded[0] === item) {
-        this.triggerTableData.servers[serverIndex].expanded = [];
-      } else {
-        this.triggerTableData.servers[serverIndex].expanded = [item];
-      }
-    },
-    hostDetails: function (url, version, hostid) {
-      window.open(url + "/hostinventories.php?hostid=" + hostid, "_blank");
-    },
-    latestData: function (url, version, hostid) {
-      if (versionPart(version, 0) >= 7) {
-        window.open(
-          url +
-            "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&hostids%5B%5D=" +
-            hostid,
-          "_blank"
-        );
-      } else if (versionPart(version, 0) >= 5) {
-        window.open(
-          url +
-            "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&filter_hostids%5B%5D=" +
-            hostid,
-          "_blank"
-        );
-      } else {
-        window.open(
-          url +
-            "/latest.php?fullscreen=0&filter_set=1&show_without_data=1&hostids%5B%5D=" +
-            hostid,
-          "_blank"
-        );
-      }
-    },
-    hostGraphs: function (url, version, hostid) {
-      if (versionPart(version, 0) >= 5) {
-        window.open(
-          url +
-            "/zabbix.php?action=charts.view&filter_set=1&view_as=showgraph&filter_search_type=0&filter_hostids%5B0%5D=" +
-            hostid,
-          "_blank"
-        );
-      } else {
-        window.open(
-          url + "/charts.php?fullscreen=0&groupid=0&graphid=0&hostid=" + hostid,
-          "_blank"
-        );
-      }
-    },
-    problemDetails: function (url, version, triggerid) {
-      if (
-        versionPart(version, 0) >= 5 ||
-        (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
-      ) {
-        window.open(
-          url +
-            "/zabbix.php?show=1&show_timeline=1&action=problem.view&triggerids%5B%5D=" +
-            triggerid,
-          "_blank"
-        );
-      } else {
-        window.open(
-          url +
-            "/zabbix.php?action=problem.view&filter_set=1&filter_triggerids%5B%5D=" +
-            triggerid,
-          "_blank"
-        );
-      }
-    },
-    hostDashboards: function (url, version, hostid) {
-      if (
-        versionPart(version, 0) > 5 ||
-        (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
-      ) {
-        window.open(
-          url + "/zabbix.php?action=host.dashboard.view&hostid=" + hostid,
-          "_blank"
-        );
-      } else {
-        window.open(url + "/host_screen.php?hostid=" + hostid, "_blank");
-      }
-      // TODO get url for pre 5.0
-    },
-    eventDetails: function (url, version, triggerid, eventid) {
-      window.open(
-        url + "/tr_events.php?triggerid=" + triggerid + "&eventid=" + eventid,
-        "_blank"
-      );
-    },
-    ackEvent: function (url, version, triggerid, eventid) {
-      if (versionPart(version, 0) >= 7) {
-        window.open(
-          url +
-            "/zabbix.php?action=popup&popup=acknowledge.edit&eventids%5B%5D=" +
-            eventid,
-          "_blank"
-        );
-      } else if (versionPart(version, 0) >= 5) {
-        window.open(
-          url +
-            "/zabbix.php?action=popup&popup_action=acknowledge.edit&eventids%5B%5D=" +
-            eventid,
-          "_blank"
-        );
-      } else {
-        window.open(
-          url + "/zabbix.php?action=acknowledge.edit&eventids[]=" + eventid,
-          "_blank"
-        );
-      }
+function date_filter(value) {
+  const curtime = new Date().getTime();
+  const diff = curtime - value * 1000;
+
+  const seconds = parseInt(diff / 1000);
+  const minutes = parseInt(seconds / 60);
+  const hours = parseInt(minutes / 60);
+  const days = parseInt(hours / 24);
+
+  let result = "";
+  if (days > 0) {
+    result += days + "d, ";
+  }
+  if (hours > 0) {
+    if (days < 1) {
+      result += (hours % 24) + "h, ";
+    } else {
+      result += (hours % 24) + "h";
     }
   }
-};
+  if (days < 1) {
+    // Only show minutes if under a day
+    result += (minutes % 60) + "m";
+  }
+
+  return result;
+}
+
+function sortSave(value, serverIndex) {
+  browser.runtime.sendMessage({
+    method: "submitPagination",
+    index: serverIndex,
+    sortBy: value[0].key,
+    descending: value[0].order,
+  });
+}
+
+function clickRow(item, serverIndex) {
+  if (triggerTableData.value.servers[serverIndex].expanded[0] === item) {
+    triggerTableData.value.servers[serverIndex].expanded = [];
+  } else {
+    triggerTableData.value.servers[serverIndex].expanded = [item];
+  }
+}
+
+function hostDetails(url, version, hostid) {
+  window.open(url + "/hostinventories.php?hostid=" + hostid, "_blank");
+}
+
+function latestData(url, version, hostid) {
+  if (versionPart(version, 0) >= 7) {
+    window.open(
+      url +
+        "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&hostids%5B%5D=" +
+        hostid,
+      "_blank"
+    );
+  } else if (versionPart(version, 0) >= 5) {
+    window.open(
+      url +
+        "/zabbix.php?action=latest.view&filter_application=&filter_select=&filter_show_without_data=1&filter_set=1&filter_hostids%5B%5D=" +
+        hostid,
+      "_blank"
+    );
+  } else {
+    window.open(
+      url +
+        "/latest.php?fullscreen=0&filter_set=1&show_without_data=1&hostids%5B%5D=" +
+        hostid,
+      "_blank"
+    );
+  }
+}
+
+function hostGraphs(url, version, hostid) {
+  if (versionPart(version, 0) >= 5) {
+    window.open(
+      url +
+        "/zabbix.php?action=charts.view&filter_set=1&view_as=showgraph&filter_search_type=0&filter_hostids%5B0%5D=" +
+        hostid,
+      "_blank"
+    );
+  } else {
+    window.open(
+      url + "/charts.php?fullscreen=0&groupid=0&graphid=0&hostid=" + hostid,
+      "_blank"
+    );
+  }
+}
+
+function problemDetails(url, version, triggerid) {
+  if (
+    versionPart(version, 0) >= 5 ||
+    (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
+  ) {
+    window.open(
+      url +
+        "/zabbix.php?show=1&show_timeline=1&action=problem.view&triggerids%5B%5D=" +
+        triggerid,
+      "_blank"
+    );
+  } else {
+    window.open(
+      url +
+        "/zabbix.php?action=problem.view&filter_set=1&filter_triggerids%5B%5D=" +
+        triggerid,
+      "_blank"
+    );
+  }
+}
+
+function hostDashboards(url, version, hostid) {
+  if (
+    versionPart(version, 0) > 5 ||
+    (versionPart(version, 0) == 5 && versionPart(version, 1) >= 2)
+  ) {
+    window.open(
+      url + "/zabbix.php?action=host.dashboard.view&hostid=" + hostid,
+      "_blank"
+    );
+  } else {
+    window.open(url + "/host_screen.php?hostid=" + hostid, "_blank");
+  }
+  // TODO get url for pre 5.0
+}
+
+function eventDetails(url, version, triggerid, eventid) {
+  window.open(
+    url + "/tr_events.php?triggerid=" + triggerid + "&eventid=" + eventid,
+    "_blank"
+  );
+}
+
+function ackEvent(url, version, triggerid, eventid) {
+  if (versionPart(version, 0) >= 7) {
+    window.open(
+      url +
+        "/zabbix.php?action=popup&popup=acknowledge.edit&eventids%5B%5D=" +
+        eventid,
+      "_blank"
+    );
+  } else if (versionPart(version, 0) >= 5) {
+    window.open(
+      url +
+        "/zabbix.php?action=popup&popup_action=acknowledge.edit&eventids%5B%5D=" +
+        eventid,
+      "_blank"
+    );
+  } else {
+    window.open(
+      url + "/zabbix.php?action=acknowledge.edit&eventids[]=" + eventid,
+      "_blank"
+    );
+  }
+}
 </script>
+
 <style>
 tr.Cdisaster,
 div.Cdisaster {

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,5 +37,7 @@ export default defineConfig({
   ],
   define: {
     __BROWSER__: JSON.stringify(target),
+    __VUE_OPTIONS_API__: false,
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
   },
 });


### PR DESCRIPTION
## Summary

Migrate both Vue components from Options API to Composition API (`<script setup>`), and enable `__VUE_OPTIONS_API__: false` to tree-shake the Options API compatibility layer from the bundle.

## Changes

### popup.vue
- Merged separate `<script setup>` (icon imports) and `<script>` (Options API) blocks into a single `<script setup>`
- `data()` → `ref()` with `.value` access in script
- `mounted()` → `onMounted()`
- All `methods` → plain functions (auto-exposed by `<script setup>`)
- Template unchanged — `$i18n` still works via global properties

### options.vue
- Same structural migration as popup.vue
- `this.$refs.form` → `const form = ref(null)` template ref
- `this.$i18n()` → `browser.i18n.getMessage()` direct calls in script
- `this.timeout` debounce → plain `let debounceTimeout` (not reactive, just a timer handle)
- `intervalRules` using `this.$i18n()` → uses `browser.i18n.getMessage()` directly

### vite.config.js
- Added `__VUE_OPTIONS_API__: false` — tree-shakes Vue Options API compat layer
- Added `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false` — removes SSR hydration debug code