### PR TITLE
refactor: tree-shake Vuetify components

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,15 +3,32 @@ import options from "./options.vue";
 import i18n from "vue-plugin-webextension-i18n";
 import "vuetify/styles";
 import { createVuetify } from 'vuetify';
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
+import { VApp } from 'vuetify/components/VApp'
+import { VBtn } from 'vuetify/components/VBtn'
+import { VCard, VCardTitle } from 'vuetify/components/VCard'
+import { VCheckbox } from 'vuetify/components/VCheckbox'
+import { VCol, VContainer, VRow, VSpacer } from 'vuetify/components/VGrid'
+import { VFooter } from 'vuetify/components/VFooter'
+import { VForm } from 'vuetify/components/VForm'
+import { VIcon } from 'vuetify/components/VIcon'
+import { VMain } from 'vuetify/components/VMain'
+import { VRadio } from 'vuetify/components/VRadio'
+import { VRadioGroup } from 'vuetify/components/VRadioGroup'
+import { VSelect } from 'vuetify/components/VSelect'
+import { VTextField } from 'vuetify/components/VTextField'
+import { VToolbar, VToolbarTitle } from 'vuetify/components/VToolbar'
 import { mdi } from 'vuetify/iconsets/mdi-svg'
 import { customAliases } from '../vuetify-icons'
 
 
-const  vuetify = createVuetify({
-  components,
-  directives,
+const vuetify = createVuetify({
+  components: {
+    VApp, VBtn, VCard, VCardTitle, VCheckbox,
+    VCol, VContainer, VRow, VSpacer,
+    VFooter, VForm, VIcon, VMain,
+    VRadio, VRadioGroup, VSelect,
+    VTextField, VToolbar, VToolbarTitle,
+  },
   icons: {
     defaultSet: 'mdi',
     aliases: customAliases,

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -3,15 +3,25 @@ import popup from "./popup.vue";
 import i18n from "vue-plugin-webextension-i18n";
 import "vuetify/styles";
 import { createVuetify } from 'vuetify';
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
+import { VAlert } from 'vuetify/components/VAlert'
+import { VApp } from 'vuetify/components/VApp'
+import { VBtn } from 'vuetify/components/VBtn'
+import { VCard } from 'vuetify/components/VCard'
+import { VCol, VContainer, VRow } from 'vuetify/components/VGrid'
+import { VDataTable } from 'vuetify/components/VDataTable'
+import { VIcon } from 'vuetify/components/VIcon'
+import { VSheet } from 'vuetify/components/VSheet'
+import { VTextField } from 'vuetify/components/VTextField'
 import { mdi } from 'vuetify/iconsets/mdi-svg'
 import { customAliases } from '../vuetify-icons'
 
 
-const  vuetify = createVuetify({
-  components,
-  directives,
+const vuetify = createVuetify({
+  components: {
+    VAlert, VApp, VBtn, VCard,
+    VCol, VContainer, VRow,
+    VDataTable, VIcon, VSheet, VTextField,
+  },
   icons: {
     defaultSet: 'mdi',
     aliases: customAliases,


### PR DESCRIPTION
## What

Replace wildcard Vuetify imports (`import * as components` / `import * as directives`) with explicit named imports for only the components actually used.

## Why

The wildcard imports pull in every Vuetify component and directive, most of which are unused. This is the single biggest contributor to bundle size.

## Changes

- **popup.js**: imports 11 components (VAlert, VApp, VBtn, VCard, VCol, VContainer, VDataTable, VIcon, VRow, VSheet, VTextField)
- **options.js**: imports 19 components (VApp, VBtn, VCard, VCardTitle, VCheckbox, VCol, VContainer, VFooter, VForm, VIcon, VMain, VRadio, VRadioGroup, VRow, VSelect, VSpacer, VTextField, VToolbar, VToolbarTitle)
- Directives registration removed — none are used explicitly in templates

## Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total dist | 1.4 MB | 976 KB | **−30%** |
| Shared Vuetify chunk (JS) | 607 KB | 290 KB | **−52%** |
| Shared Vuetify chunk (CSS) | 508 KB | 346 KB | **−32%** |

All 89 tests pass. Build succeeds cleanly.