### PR TITLE
fix: correct initalize → initialize typo

### DIFF
--- a/src/__tests__/background.test.js
+++ b/src/__tests__/background.test.js
@@ -86,7 +86,7 @@ import {
   migrateOldSettings,
   migrateCryptoFormat,
   setAlarmState,
-  initalize,
+  initialize,
   getServerTriggers,
   getAllTriggers,
   sendNotify,
@@ -995,13 +995,13 @@ describe('background.js', () => {
     });
   });
 
-  // ── initalize ─────────────────────────────────────────────────────────
+  // ── initialize ─────────────────────────────────────────────────────────
 
-  describe('initalize()', () => {
+  describe('initialize()', () => {
     it('sets alarm interval from settings and calls getAllTriggers', async () => {
       const settings = makeSettings({ global: { interval: 180 } });
 
-      // initalize calls getSettings, then setAlarmState, then getAllTriggers
+      // initialize calls getSettings, then setAlarmState, then getAllTriggers
       // getAllTriggers also calls getSettings and storage.local.get('triggerResults')
       mockBrowser.storage.local.get.mockImplementation(async (key) => {
         if (key === ZABBIX_SERVERS_KEY) {
@@ -1015,7 +1015,7 @@ describe('background.js', () => {
       mockBrowser.alarms.get.mockResolvedValue(null);
       mockZabbixInstance.call.mockResolvedValue({ result: [] });
 
-      await initalize();
+      await initialize();
 
       expect(mockBrowser.alarms.create).toHaveBeenCalledWith('default-alarm', {
         delayInMinutes: 3,
@@ -1033,7 +1033,7 @@ describe('background.js', () => {
         if (key === ZABBIX_SERVERS_KEY) {
           callCount++;
           if (callCount === 1) {
-            // First call from initalize() — no global to trigger catch
+            // First call from initialize() — no global to trigger catch
             return { [ZABBIX_SERVERS_KEY]: JSON.stringify({ servers: [makeSettings().servers[0]] }) };
           }
           // Subsequent calls from getAllTriggers — full settings
@@ -1047,7 +1047,7 @@ describe('background.js', () => {
       mockBrowser.alarms.get.mockResolvedValue(null);
       mockZabbixInstance.call.mockResolvedValue({ result: [] });
 
-      await initalize();
+      await initialize();
 
       // Should fall back to 60 seconds = 1 minute
       expect(mockBrowser.alarms.create).toHaveBeenCalledWith('default-alarm', {
@@ -1059,7 +1059,7 @@ describe('background.js', () => {
     it('does nothing when settings are null', async () => {
       stubSettings(null);
 
-      await initalize();
+      await initialize();
 
       expect(mockBrowser.alarms.create).not.toHaveBeenCalled();
     });

--- a/src/background.js
+++ b/src/background.js
@@ -22,7 +22,7 @@ const SEVERITY = Object.freeze({
 browser.runtime.onMessage.addListener(handleMessage);
 const handleAlarm = (alarm) => {
   if (alarm?.name === 'default-alarm') {
-    initalize();
+    initialize();
   }
 };
 
@@ -36,13 +36,13 @@ browser.runtime.onInstalled.addListener( async () => {
 
   await migrateOldSettings();
   await migrateCryptoFormat();
-  await initalize();
+  await initialize();
 });
 browser.runtime.onStartup.addListener( async () => {
   log(`onStartup()`);
 
   await migrateCryptoFormat();
-  await initalize();
+  await initialize();
 });
 self.addEventListener("activate", (event) => {
   log("activated for " + JSON.stringify(event))
@@ -121,7 +121,7 @@ async function setAlarmState(interval) {
 }
 
 
-async function initalize() {
+async function initialize() {
   /*
    * Set Zabbix poll alarm, listeners, and activate polling
    */
@@ -598,10 +598,10 @@ async function setActiveTriggersTable(triggerResults) {
 // eslint-disable-next-line no-unused-vars
 async function handleMessage(request, sender, sendResponse) {
   switch (request.method) {
-    case "reinitalize": {
+    case "reinitialize": {
       log("Background triggered reinialize")
       // Sent by options to alert to config changes in order to refresh
-      await initalize();
+      await initialize();
       break;
     }
     case "submitPagination": {
@@ -627,7 +627,7 @@ export {
   migrateOldSettings,
   migrateCryptoFormat,
   setAlarmState,
-  initalize,
+  initialize,
   getServerTriggers,
   getAllTriggers,
   sendNotify,

--- a/src/options/options.vue
+++ b/src/options/options.vue
@@ -371,8 +371,8 @@ async function save_data() {
     // encrypt pass and api fields
     const ZabbixServers = await encryptSettingKeys(zabbixs.value);
     await browser.storage.local.set({"ZabbixServers": JSON.stringify(ZabbixServers)});
-    console.log("Options calling reinitalize");
-    browser.runtime.sendMessage({ method: "reinitalize" });
+    console.log("Options calling reinitialize");
+    browser.runtime.sendMessage({ method: "reinitialize" });
     
     window.close();
   } else {


### PR DESCRIPTION
Fixes the `initalize` → `initialize` typo across `background.js`, `options.vue`, and the test file.

The message string `reinitialize` is a cross-file contract (options sends it, background listens), so all three files updated together.

89/89 tests pass.