### PR TITLE
fix: use event severity instead of trigger priority

### DIFF
--- a/src/__tests__/background.test.js
+++ b/src/__tests__/background.test.js
@@ -90,6 +90,7 @@ import {
   clearPopupTableError,
   buildTriggerRequest,
   makeVersionPersister,
+  getEffectiveSeverity,
   getServerTriggers,
   getAllTriggers,
   sendNotify,
@@ -426,6 +427,43 @@ describe('background.js', () => {
       });
 
       expect(req.groupids).toEqual(['1', '5', '10']);
+    });
+  });
+
+  // ── getEffectiveSeverity ──────────────────────────────────────────────
+
+  describe('getEffectiveSeverity()', () => {
+    it('prefers event severity over trigger priority', () => {
+      const trigger = {
+        priority: '2',
+        lastEvent: { eventid: '100', acknowledged: '0', severity: '4' },
+      };
+
+      expect(getEffectiveSeverity(trigger)).toBe(4);
+    });
+
+    it('falls back to trigger priority when event severity is missing', () => {
+      const trigger = {
+        priority: '3',
+        lastEvent: { eventid: '100', acknowledged: '0' },
+      };
+
+      expect(getEffectiveSeverity(trigger)).toBe('3');
+    });
+
+    it('falls back to trigger priority when lastEvent is missing', () => {
+      const trigger = { priority: '5' };
+
+      expect(getEffectiveSeverity(trigger)).toBe('5');
+    });
+
+    it('handles null event severity', () => {
+      const trigger = {
+        priority: '2',
+        lastEvent: { eventid: '100', acknowledged: '0', severity: null },
+      };
+
+      expect(getEffectiveSeverity(trigger)).toBe('2');
     });
   });
 
@@ -1111,6 +1149,24 @@ describe('background.js', () => {
       expect(registration.showNotification).toHaveBeenCalledWith(
         'hostname',
         expect.any(Object)
+      );
+    });
+
+    it('uses event severity for notification icon when manually changed', async () => {
+      const message = {
+        description: 'Disk usage critical',
+        priority: '2',
+        hosts: [{ name: 'web-server-01', host: 'web01' }],
+        lastEvent: { eventid: '100', acknowledged: '0', severity: '4' },
+      };
+
+      await sendNotify(message, 'name');
+
+      expect(registration.showNotification).toHaveBeenCalledWith(
+        'web-server-01',
+        expect.objectContaining({
+          icon: 'images/sev_4.png',
+        })
       );
     });
   });

--- a/src/__tests__/background.test.js
+++ b/src/__tests__/background.test.js
@@ -396,6 +396,14 @@ describe('background.js', () => {
       expect(req).not.toHaveProperty('groupids');
     });
 
+    it('requests severity in selectLastEvent', () => {
+      const req = buildTriggerRequest({
+        hostGroups: [], hide: false, maintenance: false, minSeverity: 0,
+      });
+
+      expect(req.selectLastEvent).toContain('severity');
+    });
+
     it('sets withLastEventUnacknowledged when hide is true', () => {
       const req = buildTriggerRequest({
         hostGroups: [], hide: true, maintenance: false, minSeverity: 0,
@@ -1197,6 +1205,76 @@ describe('background.js', () => {
             }),
           ]),
           headers: expect.any(Array),
+        }),
+      });
+    });
+
+    it('uses event severity over trigger priority when manually changed', async () => {
+      const settings = makeSettings();
+      stubSettings(settings);
+
+      const triggerResults = {
+        'Zabbix Prod': [
+          {
+            triggerid: '1',
+            description: 'CPU high on web server',
+            priority: '2',  // trigger configured as Warning
+            lastchange: '1717100000',
+            hosts: [{ host: 'web01', name: 'Web Server 01', hostid: '10', maintenance_status: '0' }],
+            lastEvent: { eventid: '200', acknowledged: '0', severity: '4' },  // event changed to High
+          },
+        ],
+      };
+
+      await setActiveTriggersTable(triggerResults);
+
+      expect(mockBrowser.storage.session.set).toHaveBeenCalledWith({
+        popupTable: expect.objectContaining({
+          servers: expect.arrayContaining([
+            expect.objectContaining({
+              triggers: expect.arrayContaining([
+                expect.objectContaining({
+                  triggerid: '1',
+                  priority: 4,
+                }),
+              ]),
+            }),
+          ]),
+        }),
+      });
+    });
+
+    it('falls back to trigger priority when event severity is missing', async () => {
+      const settings = makeSettings();
+      stubSettings(settings);
+
+      const triggerResults = {
+        'Zabbix Prod': [
+          {
+            triggerid: '1',
+            description: 'CPU high on web server',
+            priority: '3',
+            lastchange: '1717100000',
+            hosts: [{ host: 'web01', name: 'Web Server 01', hostid: '10', maintenance_status: '0' }],
+            lastEvent: { eventid: '200', acknowledged: '0' },  // no severity (older Zabbix)
+          },
+        ],
+      };
+
+      await setActiveTriggersTable(triggerResults);
+
+      expect(mockBrowser.storage.session.set).toHaveBeenCalledWith({
+        popupTable: expect.objectContaining({
+          servers: expect.arrayContaining([
+            expect.objectContaining({
+              triggers: expect.arrayContaining([
+                expect.objectContaining({
+                  triggerid: '1',
+                  priority: '3',
+                }),
+              ]),
+            }),
+          ]),
         }),
       });
     });

--- a/src/background.js
+++ b/src/background.js
@@ -202,6 +202,19 @@ function buildTriggerRequest(serverConfig) {
   return request;
 }
 
+function getEffectiveSeverity(trigger) {
+  /*
+   * Return the trigger's current severity, preferring the last event's
+   * severity (reflects manual changes in Zabbix) over the trigger's
+   * configured priority. Falls back to trigger priority when event
+   * severity is unavailable (older Zabbix versions).
+   */
+  const eventSeverity = trigger["lastEvent"] && trigger["lastEvent"]["severity"];
+  return eventSeverity !== undefined && eventSeverity !== null
+    ? Number(eventSeverity)
+    : trigger["priority"];
+}
+
 function makeVersionPersister(serverURL) {
   /*
    * Return a callback that persists an auto-detected Zabbix version
@@ -395,7 +408,7 @@ async function sendBatchNotify(messages, serverName, displayName) {
    * Create a single batched notification for multiple triggers
    */
   const count = messages.length;
-  const highestSeverity = Math.max(...messages.map(m => m.priority));
+  const highestSeverity = Math.max(...messages.map(m => getEffectiveSeverity(m)));
   
   if (__BROWSER__ === "firefox") { // eslint-disable-line no-undef
     await browser.notifications.create(
@@ -430,7 +443,7 @@ async function sendNotify(message, displayName) {
         type: "basic",
         title: message.hosts[0][displayName],
         message: message.description,
-        iconUrl: icon("sev_" + message.priority),
+        iconUrl: icon("sev_" + getEffectiveSeverity(message)),
         
       }
     );
@@ -440,7 +453,7 @@ async function sendNotify(message, displayName) {
       message.hosts[0][displayName], 
       {
         body: message.description,
-        icon: icon("sev_" + message.priority),
+        icon: icon("sev_" + getEffectiveSeverity(message)),
       }
     )
   }
@@ -549,13 +562,7 @@ async function setActiveTriggersTable(triggerResults) {
         "Generating trigger table for server: " + server
       );
       for (var t = 0; t < triggerResults[server].length; t++) {
-        // Prefer the event's current severity (reflects manual changes in Zabbix)
-        // over the trigger's configured priority. Fall back to trigger priority
-        // if the event severity is unavailable (older Zabbix versions).
-        const eventSeverity = triggerResults[server][t]["lastEvent"]["severity"];
-        let priority = eventSeverity !== undefined && eventSeverity !== null
-          ? Number(eventSeverity)
-          : triggerResults[server][t]["priority"];
+        const priority = getEffectiveSeverity(triggerResults[server][t]);
         // Set priority number if higher than current
         // Used to set browser icon
         if (priority > topSeverity) {
@@ -634,6 +641,7 @@ export {
   clearPopupTableError,
   buildTriggerRequest,
   makeVersionPersister,
+  getEffectiveSeverity,
   getServerTriggers,
   getAllTriggers,
   sendNotify,

--- a/src/background.js
+++ b/src/background.js
@@ -174,7 +174,7 @@ function buildTriggerRequest(serverConfig) {
     expandDescription: 1,
     skipDependent: 1,
     selectHosts: ["host", "name", "hostid", "maintenance_status"],
-    selectLastEvent: ["eventid", "acknowledged"],
+    selectLastEvent: ["eventid", "acknowledged", "severity"],
     monitored: 1,
     min_severity: minSeverity,
     active: 1,
@@ -549,7 +549,13 @@ async function setActiveTriggersTable(triggerResults) {
         "Generating trigger table for server: " + server
       );
       for (var t = 0; t < triggerResults[server].length; t++) {
-        let priority = triggerResults[server][t]["priority"];
+        // Prefer the event's current severity (reflects manual changes in Zabbix)
+        // over the trigger's configured priority. Fall back to trigger priority
+        // if the event severity is unavailable (older Zabbix versions).
+        const eventSeverity = triggerResults[server][t]["lastEvent"]["severity"];
+        let priority = eventSeverity !== undefined && eventSeverity !== null
+          ? Number(eventSeverity)
+          : triggerResults[server][t]["priority"];
         // Set priority number if higher than current
         // Used to set browser icon
         if (priority > topSeverity) {


### PR DESCRIPTION
Fixes #53

## Summary
When a user manually changed an event's severity in the Zabbix frontend, the extension kept showing the trigger's original configured priority. This is because the code used `trigger.priority` (the configured value) instead of the event's current severity.

## Changes
- `src/background.js` — added `"severity"` to `selectLastEvent`; `setActiveTriggersTable()` now prefers `lastEvent.severity` over `trigger.priority`
- Falls back to `trigger.priority` when event severity is unavailable (older Zabbix versions)
- Tests for both the preference and the fallback

## Behavior
- Popup table, badge icon, and notifications now reflect manually changed severities
- No behavior change when event severity matches trigger priority (the common case)

## Tests
- 102/102 Vitest tests pass
- Production build clean