### PR TITLE
docs: add npm test to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options screen displays many settings including the ability to only show problem
 
 ## Build
 `npm install`
+`npm test`
 `TARGET=chrome npm run build` or `TARGET=firefox npm run build`
 
 Then create a zip file from the dist/ directory's contents in Firefox Developer Edition or load the dist/ directory in Chrome.


### PR DESCRIPTION
Adds `npm test` to the README build section.